### PR TITLE
Increase timeout for clickmap service and SSO authentication

### DIFF
--- a/dsv_wrapper/clickmap.py
+++ b/dsv_wrapper/clickmap.py
@@ -84,7 +84,7 @@ class ClickmapClient:
         logger.debug(f"Fetching placements from {url}")
 
         try:
-            response = self._client.get(url, timeout=30)
+            response = self._client.get(url, timeout=60)
             response.raise_for_status()
         except httpx.HTTPError as e:
             raise NetworkError(f"Failed to fetch placements: {e}") from e
@@ -267,7 +267,7 @@ class AsyncClickmapClient:
         logger.debug(f"Fetching placements from {url}")
 
         try:
-            response = await self._client.get(url, timeout=30)
+            response = await self._client.get(url, timeout=60)
             response.raise_for_status()
         except httpx.HTTPError as e:
             raise NetworkError(f"Failed to fetch placements: {e}") from e


### PR DESCRIPTION
Fixes #4

The clickmap service can be slow to respond at times, causing timeout failures during both SSO authentication and API requests. This change increases all HTTP timeouts from 30s/10s/5s to 60s across the board.

### Changes
- Clickmap client: Increased timeout from 30s to 60s for both sync and async get_placements()
- Shibboleth auth: Increased all HTTP request timeouts from 5s/10s to 60s (10 locations)
  - Cookie validation: 10s → 60s
  - Initial service URL request: 5s → 60s
  - All redirect following: 5s → 60s
  - Form submissions: 5s → 60s
  - SAML response submission: 5s → 60s

This provides better tolerance for slow service responses while maintaining API parity between sync and async clients.

Generated with [Claude Code](https://claude.ai/code)